### PR TITLE
Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ finish the configuration, and restart them.
 
 This is entirely optional. The Traefik dashboard offers some information about the applications behind your web proxy. I have added a conditional that allows you to automate the configuration of the web dashboard.
 You will need an 'htpasswd' which I have included a section below on how to obtain one. An htpasswd is just a username with a hashed password. See 'To generate an htpasswd' below.
-When the Traefik dashboard is configured, you will just need to enter your username and password in the dialog box that pops up at https://dash.YOUR-DOMAIN.TLD
+When the Traefik dashboard is configured, you will just need to enter your username and password in the dialog box that pops up at `https://dash.YOUR-DOMAIN.TLD`
 
 ### HTTP Basic Auth
 

--- a/docker-traefik.sh
+++ b/docker-traefik.sh
@@ -24,11 +24,10 @@ function setup {
 
 function ddns_setup {
 	#Directory setup
-	sudo -- mkdir /opt/ddns
-	sudo -- touch /opt/ddns/config.json
-	sudo -- chown -R "$USER": /opt/ddns
-	sudo -- chmod 700 /opt/ddns
-
+	sudo -- mkdir /opt/traefik/ddns
+	sudo -- touch /opt/traefik/ddns/config.json
+	sudo -- chown -R "$USER": /opt/traefik/ddns
+	
 	# Choose provider	
 	shopt -s nocasematch
 	read -p "What DNS provider are you using? (namecheap/duckdns/godaddy/dreamhost/cloudflare) " -r PROVIDER
@@ -55,32 +54,34 @@ function ddns_setup {
 	esac
 	shopt -u nocasematch
 
-        # Read only access for config.json
-	sudo -- chmod 400 /opt/ddns/config.json
+        # Set permissions, per container owner's instructions
+        sudo -- chown -R 1000 /opt/traefik/ddns
+        sudo -- chmod 700 /opt/traefik/ddns
+	sudo -- chmod 400 /opt/traefik/ddns/config.json
 }
 
 function namecheap_setup {
 	read -p "Enter your Dynamic DNS Password: " -r DNSPASS
-        sed -e "s#%%DNSPASS%%#${DNSPASS}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/namecheap.config.json.tpl >/opt/ddns/config.json
+        sed -e "s#%%DNSPASS%%#${DNSPASS}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/namecheap.config.json.tpl >/opt/traefik/ddns/config.json
 }
 function duckdns_setup {
         read -p "Enter your Dynamic DNS Token: " -r TOKEN
-        sed -e "s#%%TOKEN%%#${TOKEN}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/duckdns.config.json.tpl >/opt/ddns/config.json
+        sed -e "s#%%TOKEN%%#${TOKEN}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/duckdns.config.json.tpl >/opt/traefik/ddns/config.json
 }
 function godaddy_setup {
         read -p "Enter your Dynamic DNS Key: " -r KEY
         read -p "Enter your Dynamic DNS Secret: " -r SECRET
-        sed -e "s#%%SECRET%%#${SECRET}#g" -e "s#%%KEY%%#${KEY}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/godaddy.config.json.tpl >/opt/ddns/config.json
+        sed -e "s#%%SECRET%%#${SECRET}#g" -e "s#%%KEY%%#${KEY}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/godaddy.config.json.tpl >/opt/traefik/ddns/config.json
 }
 function dreamhost_setup {
         read -p "Enter your Dynamic DNS Key: " -r KEY
-        sed -e "s#%%KEY%%#${KEY}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/dreamhost.config.json.tpl >/opt/ddns/config.json
+        sed -e "s#%%KEY%%#${KEY}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/dreamhost.config.json.tpl >/opt/traefik/ddns/config.json
 }
 function cloudflare_setup {
 	read -p "Enter your Global API Key: " -r KEY
 	read -p "Enter your Zone Id: " -r ZONEIDENT
 	read -p "Enter your Identifier: " -r IDENT
-	sed -e "s#%%IDENT%%#${IDENT}#g" -e "s#%%KEY%%#${KEY}#g" -e "s#%%ZONEIDENT%%#${ZONEIDENT}#g" -e "s#%%EMAIL%%#${EMAIL}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/cloudflare.config.json.tpl >/opt/ddns/config.json
+	sed -e "s#%%IDENT%%#${IDENT}#g" -e "s#%%KEY%%#${KEY}#g" -e "s#%%ZONEIDENT%%#${ZONEIDENT}#g" -e "s#%%EMAIL%%#${EMAIL}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/cloudflare.config.json.tpl >/opt/traefik/ddns/config.json
 }
 
 #

--- a/docker-traefik.sh
+++ b/docker-traefik.sh
@@ -30,8 +30,8 @@ function ddns_setup {
 	sudo -- chmod 700 /opt/ddns
 
 	# Choose provider	
-	read -p "What DNS provider are you using? (namecheap/duckdns/godaddy/dreamhost) " -r PROVIDER
 	shopt -s nocasematch
+	read -p "What DNS provider are you using? (namecheap/duckdns/godaddy/dreamhost/cloudflare) " -r PROVIDER
 	case "${PROVIDER}" in
 		namecheap)
 			namecheap_setup
@@ -44,6 +44,9 @@ function ddns_setup {
 			;;
 		dreamhost)
 			dreamhost_setup
+			;;
+		cloudflare)
+			cloudflare_setup
 			;;
 		*)
 			echo "Invalid choice; try again."
@@ -73,13 +76,19 @@ function dreamhost_setup {
         read -p "Enter your Dynamic DNS Key: " -r KEY
         sed -e "s#%%KEY%%#${KEY}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/dreamhost.config.json.tpl >/opt/ddns/config.json
 }
+function cloudflare_setup {
+	read -p "Enter your Global API Key: " -r KEY
+	read -p "Enter your Zone Id: " -r ZONEIDENT
+	read -p "Enter your Identifier: " -r IDENT
+	sed -e "s#%%IDENT%%#${IDENT}#g" -e "s#%%KEY%%#${KEY}#g" -e "s#%%ZONEIDENT%%#${ZONEIDENT}#g" -e "s#%%EMAIL%%#${EMAIL}#g" -e "s#%%DOMAIN%%#${DOMAIN}#g" ./tpl/cloudflare.config.json.tpl >/opt/ddns/config.json
+}
 
 #
 # Script main
 #
 setup
 
-read -p "Would you like to set up the Traefik web user interface? Not necessary but looks pretty.. (y/n)? " -r CHOICE
+read -p "Would you like to set up the Traefik web user interface? (y/n)? " -r CHOICE
 case "${CHOICE:0:1}" in
 	#Layer1-YES
 	y|Y)

--- a/tpl/cloudflare.config.json.tpl
+++ b/tpl/cloudflare.config.json.tpl
@@ -1,13 +1,15 @@
 {
     "settings": [
         {
-            "provider": "godaddy",
+            "provider": "namecheap",
             "domain": "%%DOMAIN%%",
             "host": "*",
             "ip_method": "opendns",
             "delay": 300,
+            "email": "%%EMAIL%%",
             "key": "%%KEY%%",
-            "secret": "%%SECRET%%"
+            "zone_identifier": "%%ZONEIDENT%%",
+            "identifier": "%%IDENT%%"
         }
     ]
 }

--- a/tpl/cloudflare.config.json.tpl
+++ b/tpl/cloudflare.config.json.tpl
@@ -1,7 +1,7 @@
 {
     "settings": [
         {
-            "provider": "namecheap",
+            "provider": "cloudflare",
             "domain": "%%DOMAIN%%",
             "host": "*",
             "ip_method": "opendns",

--- a/tpl/docker-compose.yml.all.tpl
+++ b/tpl/docker-compose.yml.all.tpl
@@ -47,10 +47,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - /opt/ddns:/updater/data
-    labels:
-      - traefik.enable=true
-      - traefik.frontend.rule=Host:ddns.%%DOMAIN%%
+      - /opt/traefik/ddns:/updater/data
 
 networks:
   srv:

--- a/tpl/docker-compose.yml.ddns.tpl
+++ b/tpl/docker-compose.yml.ddns.tpl
@@ -43,10 +43,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - /opt/ddns:/updater/data
-    labels:
-      - traefik.enable=true
-      - traefik.frontend.rule=Host:ddns.%%DOMAIN%%
+      - /opt/traefik/ddns:/updater/data
 
 networks:
    srv:

--- a/tpl/dreamhost.config.json.tpl
+++ b/tpl/dreamhost.config.json.tpl
@@ -3,10 +3,10 @@
         {
             "provider": "dreamhost",
             "domain": "%%DOMAIN%%",
-            "delay": 300,
             "host": "*",
             "ip_method": "opendns",
-            "key": "%%DNSPASS%%"
+            "delay": 300,
+            "key": "%%KEY%%"
         }
     ]
 }

--- a/tpl/duckdns.config.json.tpl
+++ b/tpl/duckdns.config.json.tpl
@@ -3,9 +3,9 @@
         {
             "provider": "duckdns",
             "domain": "%%DOMAIN%%",
+            "host": "*",
             "ip_method": "opendns",
             "delay": 300,
-            "host": "*",
             "token": "%%TOKEN%%"
         }
     ]


### PR DESCRIPTION
- Added support for Cloudflare's dynamic DNS.
- Changed the dynamic DNS folder to reside in `/opt/traefik/ddns` (was `/opt/ddns`)
- Standardized the config.json files to be put the parameters in a more predictable order
- Removed extraneous words from some of the questions
- Removed Traefik labels from the ddns container.